### PR TITLE
fix: Resolve error on first load

### DIFF
--- a/homeassistant/components/hyundai_kia_connect/__init__.py
+++ b/homeassistant/components/hyundai_kia_connect/__init__.py
@@ -12,6 +12,8 @@ PLATFORMS: list[str] = [Platform.SENSOR]
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {}
     """Set up Hyundai / Kia Connect from a config entry."""
     coordinator = HyundaiKiaConnectDataUpdateCoordinator(hass, config_entry)
     await coordinator.async_refresh()


### PR DESCRIPTION
Resolves this error: 

2021-12-24 03:08:50 ERROR (MainThread) [homeassistant.config_entries] Error setting up entry SORENTO (UMA) SXL (BROWN NAPPA for hyundai_kia_connect
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/config_entries.py", line 333, in async_setup
    result = await component.async_setup_entry(hass, self)  # type: ignore
  File "/workspaces/core/homeassistant/components/hyundai_kia_connect/__init__.py", line 19, in async_setup_entry
    hass.data[DOMAIN][config_entry.entry_id] = coordinator
KeyError: 'hyundai_kia_connect'
